### PR TITLE
feat(core): implement calendar merging functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,52 @@ A Python library to merge iCalendar feeds.
 
 ## Installation
 
-Install this via pip (or your favourite package manager):
+Install this via pip (or your favorite package manager):
 
-`pip install mergecal`
+```bash
+pip install mergecal
+```
+
+## Usage
+
+### Python API
+
+You can use MergeCal in your Python code as follows:
 
 ```python
 import mergecal
-import icalendar
+from icalendar import Calendar
 
-calendar1 = icalendar.Calendar.from_ical("...")
-calendar2 = icalendar.Calendar.from_ical("...")
+# Load your calendars
+calendar1 = Calendar.from_ical(open("calendar1.ics", "rb").read())
+calendar2 = Calendar.from_ical(open("calendar2.ics", "rb").read())
 
-merged_cal = mergeal.merge([calendar1, calendar2], strategy="different-calendars")
+# Merge the calendars
+merger = mergecal.CalendarMerger([calendar1, calendar2])
+merged_cal = merger.merge()
+
+# Write the merged calendar to a file
+with open("merged_calendar.ics", "wb") as f:
+    f.write(merged_cal.to_ical())
+```
+
+### Command Line Interface (CLI)
+
+MergeCal also provides a command-line interface for easy merging of calendar files:
+
+```bash
+# Basic usage
+mergecal calendar1.ics calendar2.ics -o merged_calendar.ics
+
+# Specifying custom PRODID
+mergecal calendar1.ics calendar2.ics -o merged_calendar.ics --prodid "-//My Organization//MergeCal 1.0//EN"
+
+```
+
+For more options and information, use the help command:
+
+```bash
+mergecal --help
 ```
 
 ## Contributors ✨

--- a/src/mergecal/cli.py
+++ b/src/mergecal/cli.py
@@ -1,12 +1,51 @@
+from pathlib import Path
+from typing import List, Optional
+
 import typer
+from icalendar import Calendar
 from rich import print
 
-from .main import add
+from .main import CalendarMerger
 
 app = typer.Typer()
 
+# Define arguments and options outside of the function
+calendars_arg = typer.Argument(..., help="Paths to the calendar files to merge")
+output_opt = typer.Option(
+    "merged_calendar.ics", "--output", "-o", help="Output file path"
+)
+prodid_opt = typer.Option(None, "--prodid", help="Product ID for the merged calendar")
+calscale_opt = typer.Option(None, "--calscale", help="Calendar scale")
+method_opt = typer.Option(None, "--method", help="Calendar method")
+
 
 @app.command()
-def main(n1: int, n2: int) -> None:
-    """Add the arguments and print the result."""
-    print(add(n1, n2))
+def main(
+    calendars: List[Path] = calendars_arg,
+    output: Path = output_opt,
+    prodid: Optional[str] = prodid_opt,
+    calscale: Optional[str] = calscale_opt,
+    method: Optional[str] = method_opt,
+) -> None:
+    """Merge multiple iCalendar files into one."""
+    try:
+        calendar_objects = []
+        for calendar_path in calendars:
+            with open(calendar_path, "rb") as cal_file:
+                calendar_objects.append(Calendar.from_ical(cal_file.read()))
+
+        merger = CalendarMerger(
+            calendars=calendar_objects, prodid=prodid, calscale=calscale, method=method
+        )
+        merged_calendar = merger.merge()
+
+        with open(output, "wb") as output_file:
+            output_file.write(merged_calendar.to_ical())
+
+        print(f"[green]Successfully merged calendars into {output}[/green]")
+    except Exception as e:
+        print(f"[red]Error merging calendars: {e!s}[/red]")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from icalendar import Calendar, Event
 from typer.testing import CliRunner
 
 from mergecal.cli import app
@@ -5,8 +8,44 @@ from mergecal.cli import app
 runner = CliRunner()
 
 
-def test_help():
-    """The help message includes the CLI name."""
-    result = runner.invoke(app, ["--help"])
+def create_test_calendar_file(filename, summary, dtstart):
+    cal = Calendar()
+    event = Event()
+    event.add("summary", summary)
+    event.add("dtstart", dtstart)
+    cal.add_component(event)
+
+    with open(filename, "wb") as f:
+        f.write(cal.to_ical())
+
+
+def test_mergecal_cli(tmp_path):
+    # Create two test calendar files
+    cal1_path = tmp_path / "cal1.ics"
+    cal2_path = tmp_path / "cal2.ics"
+    output_path = tmp_path / "merged.ics"
+
+    create_test_calendar_file(cal1_path, "Test Event 1", datetime(2023, 1, 1, 9, 0, 0))
+    create_test_calendar_file(cal2_path, "Test Event 2", datetime(2023, 1, 2, 10, 0, 0))
+
+    # Run the CLI command
+    result = runner.invoke(
+        app, [str(cal1_path), str(cal2_path), "-o", str(output_path)]
+    )
+
+    # Check that the command was successful
     assert result.exit_code == 0
-    assert "Add the arguments and print the result" in result.stdout
+    assert "Successfully merged calendars" in result.stdout
+
+    # Verify the merged calendar file
+    assert output_path.exists()
+
+    with open(output_path, "rb") as f:
+        merged_cal = Calendar.from_ical(f.read())
+
+    events = [
+        component for component in merged_cal.walk() if component.name == "VEVENT"
+    ]
+    assert len(events) == 2
+    assert events[0]["summary"] == "Test Event 1"
+    assert events[1]["summary"] == "Test Event 2"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,37 @@
-from mergecal.main import add
+from datetime import datetime
+
+from icalendar import Calendar, Event
+
+from mergecal.main import CalendarMerger
 
 
-def test_add():
-    """Adding two number works as expected."""
-    assert add(1, 1) == 2
+def create_test_calendar(summary, dtstart):
+    cal = Calendar()
+    event = Event()
+    event.add("summary", summary)
+    event.add("dtstart", dtstart)
+    cal.add_component(event)
+    return cal
+
+
+def test_calendar_merger():
+    # Create two test calendars
+    cal1 = create_test_calendar("Test Event 1", datetime(2023, 1, 1, 9, 0, 0))
+    cal2 = create_test_calendar("Test Event 2", datetime(2023, 1, 2, 10, 0, 0))
+
+    # Create a CalendarMerger instance
+    merger = CalendarMerger([cal1, cal2])
+
+    # Merge the calendars
+    merged_cal = merger.merge()
+
+    # Check that the merged calendar has both events
+    events = [
+        component for component in merged_cal.walk() if component.name == "VEVENT"
+    ]
+    assert len(events) == 2
+    assert events[0]["summary"] == "Test Event 1"
+    assert events[1]["summary"] == "Test Event 2"
+
+    # Check that the PRODID is set correctly
+    assert merged_cal["prodid"].startswith("-//mergecal.org//MergeCal//")


### PR DESCRIPTION
- Add CalendarMerger class to handle merging of multiple calendars
- Implement CLI interface using Typer for calendar merging operations
- Create unit tests for calendar merging functionality
- Update main.py to include core merging logic
- Refactor CLI to use new CalendarMerger class
- Add type hints throughout the codebase

This commit introduces the primary functionality of MergeCal, allowing users to merge multiple iCalendar files both programmatically and via the command line interface.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/abe-101/mergecal/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/abe-101/mergecal/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
