### PR TITLE
refactor: remove --calscale option

### DIFF
--- a/src/mergecal/calendar_merger.py
+++ b/src/mergecal/calendar_merger.py
@@ -16,7 +16,6 @@ class CalendarMerger:
         calendars: list[Calendar],
         prodid: Optional[str] = None,
         version: str = "2.0",
-        calscale: Optional[str] = None,
         method: Optional[str] = None,
     ):
         if not calendars:
@@ -29,8 +28,6 @@ class CalendarMerger:
         self.merged_calendar.add("version", version)
 
         # Set optional properties if provided
-        if calscale:
-            self.merged_calendar.add("calscale", calscale)
         if method:
             self.merged_calendar.add("method", method)
 

--- a/src/mergecal/cli.py
+++ b/src/mergecal/cli.py
@@ -15,7 +15,6 @@ output_opt = typer.Option(
     "merged_calendar.ics", "--output", "-o", help="Output file path"
 )
 prodid_opt = typer.Option(None, "--prodid", help="Product ID for the merged calendar")
-calscale_opt = typer.Option(None, "--calscale", help="Calendar scale")
 method_opt = typer.Option(None, "--method", help="Calendar method")
 
 
@@ -24,7 +23,6 @@ def main(
     calendars: list[Path] = calendars_arg,
     output: Path = output_opt,
     prodid: Optional[str] = prodid_opt,
-    calscale: Optional[str] = calscale_opt,
     method: Optional[str] = method_opt,
 ) -> None:
     """Merge multiple iCalendar files into one."""
@@ -35,7 +33,7 @@ def main(
                 calendar_objects.append(Calendar.from_ical(cal_file.read()))
 
         merger = CalendarMerger(
-            calendars=calendar_objects, prodid=prodid, calscale=calscale, method=method
+            calendars=calendar_objects, prodid=prodid, method=method
         )
         merged_calendar = merger.merge()
 


### PR DESCRIPTION
Closes #15

In the real world this commit would be a breaking change but to avoid bumping up the version I'm leaving it as is

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/abe-101/mergecal/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/abe-101/mergecal/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
