### PR TITLE
feat: add CALSCALE property to merged calendars for RFC 5545 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can use MergeCal in your Python code as follows:
 
 # Write the merged calendar to a file
 >>> (CALENDARS / "merged_calendar.ics").write_bytes(merged_calendar.to_ical())
-933
+953
 
 # The merged calendar will contain all the events of both calendars
 >>> [str(event["SUMMARY"]) for event in calendar1.walk("VEVENT")]

--- a/src/mergecal/calendar_merger.py
+++ b/src/mergecal/calendar_merger.py
@@ -17,6 +17,7 @@ class CalendarMerger:
         calendars: list[Calendar],
         prodid: Optional[str] = None,
         version: str = "2.0",
+        calscale: str = "GREGORIAN",
         method: Optional[str] = None,
     ):
         self.merged_calendar = Calendar()
@@ -24,6 +25,7 @@ class CalendarMerger:
         # Set required properties
         self.merged_calendar.add("prodid", prodid or generate_default_prodid())
         self.merged_calendar.add("version", version)
+        self.merged_calendar.add("calscale", calscale)
 
         # Set optional properties if provided
         if method:

--- a/tests/test_rfc5545_compliance.py
+++ b/tests/test_rfc5545_compliance.py
@@ -1,0 +1,64 @@
+"""Tests for RFC 5545 compliance."""
+
+from mergecal import CalendarMerger, merge_calendars
+
+
+def test_empty_merge_has_required_properties():
+    """Empty merge should include all standard RFC 5545 properties."""
+    result = merge_calendars([])
+
+    assert result.get("VERSION") == "2.0"
+    assert result.get("PRODID") is not None
+    assert "-//mergecal.org//MergeCal//EN" in str(result.get("PRODID"))
+    assert result.get("CALSCALE") == "GREGORIAN"
+
+
+def test_custom_calscale_parameter():
+    """Should accept custom calendar scale values."""
+    result = merge_calendars([], calscale="JULIAN")
+    assert result.get("CALSCALE") == "JULIAN"
+
+
+def test_calendar_merger_calscale_parameter():
+    """CalendarMerger should accept calscale parameter."""
+    merger = CalendarMerger([], calscale="HEBREW")
+    result = merger.merge()
+    assert result.get("CALSCALE") == "HEBREW"
+
+
+def test_calscale_defaults_to_gregorian():
+    """CALSCALE should default to GREGORIAN when not specified."""
+    merger = CalendarMerger([])
+    result = merger.merge()
+    assert result.get("CALSCALE") == "GREGORIAN"
+
+
+def test_merged_calendar_properties_complete(merge):
+    """Merged calendar should have all expected properties."""
+    result = merge([])
+
+    ics_content = result.to_ical().decode("utf-8")
+    assert "BEGIN:VCALENDAR" in ics_content
+    assert "VERSION:2.0" in ics_content
+    assert "PRODID:" in ics_content
+    assert "CALSCALE:GREGORIAN" in ics_content
+    assert "END:VCALENDAR" in ics_content
+
+
+def test_method_parameter_still_works():
+    """Existing METHOD parameter should continue working."""
+    result = merge_calendars([], method="PUBLISH")
+    assert result.get("METHOD") == "PUBLISH"
+    assert result.get("CALSCALE") == "GREGORIAN"
+
+
+def test_all_parameters_together():
+    """All parameters should work together."""
+    result = merge_calendars(
+        [], calscale="ISLAMIC", method="REQUEST", prodid="-//Custom//App//EN"
+    )
+
+    assert result.get("CALSCALE") == "ISLAMIC"
+    assert result.get("METHOD") == "REQUEST"
+    assert result.get("PRODID") == "-//Custom//App//EN"
+    assert result.get("VERSION") == "2.0"


### PR DESCRIPTION
Closes #134

RFC 5545 defines CALSCALE as an optional property that defaults to "GREGORIAN". Previously, merged calendars only included PRODID and VERSION properties but omitted CALSCALE, reducing compatibility with strict calendar applications.

This adds a `calscale` parameter to `CalendarMerger.__init__()` with default "GREGORIAN" value and sets the CALSCALE property in merged calendars. Maintains backward compatibility while supporting non-Gregorian calendar scales as requested in the issue.