### PR TITLE
fix: raise RuntimeError when merge() is called more than once

### DIFF
--- a/src/mergecal/calendar_merger.py
+++ b/src/mergecal/calendar_merger.py
@@ -63,6 +63,7 @@ class CalendarMerger:
             self.merged_calendar.add("method", method)
 
         self.calendars: list[Calendar] = []
+        self._merged = False
 
         for calendar in calendars:
             self.add_calendar(calendar)
@@ -73,6 +74,12 @@ class CalendarMerger:
 
     def merge(self) -> Calendar:
         """Merge the calendars."""
+        if self._merged:
+            raise RuntimeError(
+                "merge() can only be called once; "
+                "create a new CalendarMerger instance to merge again"
+            )
+        self._merged = True
         tracker = _ComponentTracker(self.merged_calendar)
         tzids: set[str] = set()
 

--- a/tests/test_merge_twice.py
+++ b/tests/test_merge_twice.py
@@ -1,0 +1,12 @@
+"""Tests that CalendarMerger.merge() follows the Method Object pattern."""
+
+import pytest
+
+from mergecal import CalendarMerger
+
+
+def test_merge_called_twice_raises(calendars):
+    merger = CalendarMerger(calendars.one_event.stream)
+    merger.merge()
+    with pytest.raises(RuntimeError, match="merge\\(\\) can only be called once"):
+        merger.merge()


### PR DESCRIPTION
Closes #135

`CalendarMerger` is a Method Object — `merge()` is a one-shot operation. Calling it a second time previously accumulated duplicate components into `self.merged_calendar`, producing a different (larger) result on each call.

Adds a `_merged` flag that is set on the first call. Any subsequent call raises `RuntimeError` with a message pointing to the correct fix: create a new `CalendarMerger` instance.